### PR TITLE
Use GitHub Secrets for MySQL password in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       db:
         image: mysql:8.0
         env:
-          MYSQL_ROOT_PASSWORD: password
+          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
           MYSQL_DATABASE: ikuji_test
         ports:
           - 3306:3306


### PR DESCRIPTION
- Replaced hardcoded MYSQL_ROOT_PASSWORD with GitHub Actions secret
- Improved security and prepared for public repository compatibility