### PR TITLE
Fix notifications and feed record handling

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -3,13 +3,7 @@ class FeedsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    if current_child
-      @feeds = current_child.feeds.order(fed_at: :desc)
-    else
-      @feeds = Feed.none  # 空の ActiveRecord::Relation を返す
-      flash[:alert] = "表示する子供が選択されていません。"
-      redirect_to root_path and return
-    end
+    @feeds = current_child.feeds.order(fed_at: :desc)
   end
 
   def show

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,5 +1,4 @@
 class NotificationsController < ApplicationController
-
   def index
     @notifications = current_child.notifications.order(delivered_at: :desc)
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,6 +1,10 @@
 class NotificationsController < ApplicationController
+
   def index
     @notifications = current_child.notifications.order(delivered_at: :desc)
+
+    # 一覧ページを開いたタイミングで既読にする
+    @notifications.where(read: false).update_all(read: true)
   end
 
   # 最新の通知を返す

--- a/app/javascript/notifications.js
+++ b/app/javascript/notifications.js
@@ -11,15 +11,7 @@ document.addEventListener("turbo:load", () => {
       if (data && data.id) {
         // ポップアップ表示
         showNotification(data.title, data.message)
-
-        // 既読にする
-        fetch(`/notifications/${data.id}/mark_as_read?child_id=${childId}`, {
-          method: "PATCH",
-          headers: {
-            "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content,
-            "Content-Type": "application/json"
-          }
-        })
+    
       }
     })
     .catch(error => console.error("通知取得エラー:", error))

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -18,7 +18,7 @@ class Feed < ApplicationRecord
     last_feed = child.feeds.order(fed_at: :desc).second # 今回の直前の授乳
     return unless last_feed
 
-    hours_since_last_feed = ((Time.current - last_feed.fed_at) / 1.hour).round(1)
+    hours_since_last_feed = ((self.fed_at - last_feed.fed_at) / 1.hour).round(1)
 
     if hours_since_last_feed >= 3 && hours_since_last_feed < 5
       # リマインダー通知


### PR DESCRIPTION
- FeedsController#index: Removed nil check for current_child; always fetch feeds
- NotificationsController#index: Mark unread notifications as read when visiting the index page
- notifications.js: Removed marking notifications as read on popup; now handled on index page
- Feed model: Changed hours calculation for notifications to use self.fed_at instead of Time.current