### PR TITLE
Add user association to schedules and implement default notifications

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -25,7 +25,7 @@ class SchedulesController < ApplicationController
   end
 
   def create
-      @schedule = current_child.schedules.new(schedule_params)
+      @schedule = current_child.schedules.new(schedule_params.merge(user: current_user))
     if @schedule.save
       redirect_to child_schedules_path(current_child), notice: "予定を登録しました"
     else

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,4 +1,6 @@
 class Schedule < ApplicationRecord
+  include Notifiable
+  belongs_to :user
   belongs_to :child
 
   validates :start_time, presence: true
@@ -16,6 +18,37 @@ class Schedule < ApplicationRecord
     return if end_time.blank? || start_time.blank?
     if end_time < start_time
       errors.add(:end_time, "は開始時刻以降にしてください")
+    end
+  end
+
+  def create_default_notification
+    today = Time.zone.today
+    days_until = (start_time.to_date - today).to_i
+
+    # 3日前リマインダー
+    if days_until == 3
+      Notification.create!(
+        user: user,
+        child: child,
+        target: self,
+        notification_kind: :reminder,
+        title: "📅 スケジュール",
+        message: "リマインダー: 3日後に予定があります (#{title})",
+        delivered_at: Time.current
+      )
+    end
+
+    # 当日アラート
+    if days_until == 0
+      Notification.create!(
+        user: user,
+        child: child,
+        target: self,
+        notification_kind: :alert,
+        title: "📅 スケジュール",
+        message: "アラート: 本日の予定があります (#{title})",
+        delivered_at: Time.current
+      )
     end
   end
 end

--- a/db/migrate/20250826173419_add_user_to_schedules.rb
+++ b/db/migrate/20250826173419_add_user_to_schedules.rb
@@ -1,0 +1,8 @@
+class AddUserToSchedules < ActiveRecord::Migration[8.0]
+  def change
+    # schedules テーブルに user_id カラムが存在しなければ追加
+    unless column_exists?(:schedules, :user_id)
+      add_reference :schedules, :user, null: true, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_26_160449) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_26_173419) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -154,7 +154,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_26_160449) do
     t.text "memo"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
     t.index ["child_id"], name: "index_schedules_on_child_id"
+    t.index ["user_id"], name: "index_schedules_on_user_id"
   end
 
   create_table "sleep_records", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -232,6 +234,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_26_160449) do
   add_foreign_key "notifications", "children"
   add_foreign_key "notifications", "users"
   add_foreign_key "schedules", "children"
+  add_foreign_key "schedules", "users"
   add_foreign_key "sleep_records", "children"
   add_foreign_key "sleep_records", "users"
   add_foreign_key "temperatures", "children"


### PR DESCRIPTION
- SchedulesController#create now merges current_user to associate the schedule with a user
- Schedule model now belongs_to :user and includes Notifiable
- Added create_default_notification to send 3-day reminder and same-day alert based on start_time
- Updated schema to reflect user_id in schedules with proper indexes and foreign key