### PR TITLE
Add Chart.js bar chart to schedules#index (temporary view)

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -6,3 +6,25 @@ Rails.start();
 
 import { showNotification } from "./notification_popup";
 import "./notifications"
+
+import { Chart, registerables } from "chart.js";
+Chart.register(...registerables);
+
+
+document.addEventListener("DOMContentLoaded", () => {
+  const ctx = document.getElementById("myChart");
+  if (ctx) {
+    new Chart(ctx, {
+      type: "bar",
+      data: {
+        labels: ["Red", "Blue", "Yellow"],
+        datasets: [{
+          label: "# of Votes",
+          data: [12, 19, 3],
+          backgroundColor: ["red", "blue", "yellow"]
+        }]
+      },
+      options: {}
+    });
+  }
+});

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -1,5 +1,8 @@
 <h1>スケジュール一覧</h1>
 
+
+<canvas id="myChart" width="400" height="200"></canvas>
+
 <h2>カレンダー</h2>
 <div class="calendar-container">
   <h1 class="calendar-title"><%= @month.strftime("%Y年%m月") %></h1>

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@hotwired/turbo-rails": "^8.0.16",
-    "@rails/ujs": "^7.1.3-4"
+    "@rails/ujs": "^7.1.3-4",
+    "chart.js": "^4.5.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -145,6 +145,11 @@
   resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-8.0.13.tgz#ab35fda9d358432c8a872a833844b38cccb8c25b"
   integrity sha512-M7qXUqcGab6G5PKOiwhgbByTtrPgKPFCTMNQ52QhzUEXEqmp0/ApEguUesh/FPiUjrmFec+3lq98KsWnYY2C7g==
 
+"@kurkle/color@^0.3.0":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.4.tgz#4d4ff677e1609214fc71c580125ddddd86abcabf"
+  integrity sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==
+
 "@rails/actioncable@>=7.0":
   version "8.0.200"
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-8.0.200.tgz#1d27d9d55e45266e061190db045925e0b4d53d6b"
@@ -154,6 +159,13 @@
   version "7.1.3-4"
   resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-7.1.3-4.tgz#1dddea99d5c042e8513973ea709b2cb7e840dc2d"
   integrity sha512-z0ckI5jrAJfImcObjMT1RBz2IxH6I5q6ZTMFex6AfxSQKZuuL8JxAXvg2CvBuodGCxKvybFVolDyMHXlBLeYAA==
+
+chart.js@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.5.0.tgz#11a1ef6c4befc514b1b0b613ebac226c4ad2740b"
+  integrity sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==
+  dependencies:
+    "@kurkle/color" "^0.3.0"
 
 esbuild@^0.25.7:
   version "0.25.8"


### PR DESCRIPTION
- Installed chart.js via yarn and registered it in application.js
- Added simple bar chart in schedules#index as a placeholder/demo
- Wrapped chart initialization in DOMContentLoaded check
- Note: This chart in schedules#index is temporary; actual analysis will be in a dedicated growth analysis view