### PR TITLE
Add weekly sleep analysis page

### DIFF
--- a/app/controllers/sleep_records_controller.rb
+++ b/app/controllers/sleep_records_controller.rb
@@ -44,6 +44,38 @@ class SleepRecordsController < ApplicationController
     redirect_to child_sleep_records_path(current_child), notice: "記録を削除しました"
   end
 
+  def analysis
+    # 直近週（日曜日始まり）
+    @start_date = Date.today.beginning_of_week(:sunday)
+    @end_date   = Date.today.end_of_week(:saturday).end_of_day
+
+    # 対象期間のレコード取得
+    records = current_child.sleep_records
+                           .where.not(start_time: nil, end_time: nil)
+                           .where(start_time: @start_date..@end_date)
+
+    # 平均睡眠時間（分）
+    durations = records.map do |r|
+      ((r.end_time - r.start_time) / 60).to_i
+    end
+
+    @average_sleep_minutes = if durations.any?
+      (durations.sum / durations.size.to_f).round(1)
+    else
+      0
+    end
+
+    # 週別合計睡眠時間（◯月第◯週表記）
+    @weekly_sleep = records.group_by { |r| r.start_time.beginning_of_week(:sunday).to_date }
+                           .transform_keys { |d| "#{d.month}月第#{((d.day - 1)/7 + 1)}週" }
+                           .transform_values do |arr|
+      arr.sum { |r| ((r.end_time - r.start_time)/60).to_i }
+    end
+
+    # 昼寝パターン（日中 09:00〜17:00）
+    @daytime_naps = records.count { |r| r.start_time.hour.between?(9,16) }
+  end
+
   private
 
   # フォームから送信されたパラメータのうち、許可するキーを指定

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -14,3 +14,8 @@ import "./growth_weight";
 
 // ダッシュボード表示用
 import "./dashboard_chart";
+
+// 睡眠分析表示用
+import "./sleep_analysis_controller";
+
+

--- a/app/javascript/sleep_analysis_controller.js
+++ b/app/javascript/sleep_analysis_controller.js
@@ -1,0 +1,27 @@
+import Chart from "chart.js/auto";
+
+document.addEventListener("turbo:load", () => {
+  const canvas = document.getElementById("weeklySleepChart");
+  if (!canvas) return;
+
+  const labels = JSON.parse(canvas.dataset.labels || "[]");
+  const values = JSON.parse(canvas.dataset.values || "[]");
+
+  new Chart(canvas.getContext("2d"), {
+    type: "bar",
+    data: {
+      labels: labels,
+      datasets: [{
+        label: "週別合計睡眠時間（分）",
+        data: values,
+        backgroundColor: "rgba(54, 162, 235, 0.5)"
+      }]
+    },
+    options: {
+      responsive: true,
+      scales: {
+        y: { beginAtZero: true }
+      }
+    }
+  });
+});

--- a/app/views/sleep_records/analysis.html.erb
+++ b/app/views/sleep_records/analysis.html.erb
@@ -1,0 +1,11 @@
+<h2 class="responsive-title"><%= current_child.name %> の睡眠分析</h2>
+
+<p>集計期間: <%= @start_date.strftime("%Y-%m-%d") %> 〜 <%= @end_date.strftime("%Y-%m-%d") %></p>
+<p>平均睡眠時間: <%= (@average_sleep_minutes / 60.0).round(1) %> 時間</p>
+<p>昼寝パターン（日中 09:00〜17:00 の回数）: <%= @daytime_naps %> 回</p>
+
+<canvas id="weeklySleepChart"
+        width="400" height="200"
+        data-labels='<%= @weekly_sleep.keys.to_json %>'
+        data-values='<%= @weekly_sleep.values.to_json %>'>
+</canvas>

--- a/app/views/sleep_records/index.html.erb
+++ b/app/views/sleep_records/index.html.erb
@@ -32,3 +32,4 @@
 </table>
 
 <%= link_to "新規追加", new_child_sleep_record_path(current_child), class: "index-btn" %>
+<%= link_to "睡眠分析を見る", analysis_child_sleep_records_path(current_child), class: "index-btn" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,11 @@ Rails.application.routes.draw do
    resources :bottles
    resources :hydrations
    resources :baby_foods
-   resources :sleep_records
+   resources :sleep_records do
+     collection do
+        get :analysis  # 追加: 睡眠分析ページ
+      end
+    end
    resources :temperatures
    resources :baths
    resources :vaccinations


### PR DESCRIPTION
- Added `analysis` action in SleepRecordsController to display:
  - Average sleep time (minutes) for the current week (Sunday-Saturday)
  - Weekly total sleep time (shown as "Month ◯ Week")
  - Daytime naps count (09:00–17:00)
- Updated routes to include `analysis` as a collection route for sleep_records
- Added "View Sleep Analysis" button on sleep_records index page
- Imported `sleep_analysis_controller.js` in application.js to render Chart.js graphs