### PR TITLE
Add profile fields to User model and link profile editing in header

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,12 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :authenticate_user!
+
+  private
+
+  def account_update_params
+    params.require(:user).permit(
+      :email, :name, :bio, :avatar, 
+      :password, :password_confirmation, :current_password
+    )
+  end
+end

--- a/app/helpers/users/registrations_helper.rb
+++ b/app/helpers/users/registrations_helper.rb
@@ -1,0 +1,2 @@
+module Users::RegistrationsHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,4 +14,11 @@ class User < ApplicationRecord
 
   # 通知との関連
   has_many :notifications, dependent: :destroy
+
+  # Avatar（ActiveStorage）
+  has_one_attached :avatar
+
+  # バリデーション
+  validates :name, presence: true, length: { maximum: 50 }
+  validates :bio, length: { maximum: 300 }
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -69,6 +69,7 @@
             <%= link_to "スケジュールの登録", new_child_schedule_path(current_child), class: "nav-btn" %>
             <%= link_to "成長記録", child_growths_path(current_child), class: "nav-btn" %>
             <%= link_to "成長記録の登録", new_child_growth_path(current_child), class: "nav-btn" %>
+            <%= link_to "プロフィール編集", edit_user_registration_path, class: "nav-btn" %>
             <%= link_to notifications_path(current_child), class: "notification-link" do %>
               <i class="fa fa-bell"></i>
               <% if current_user.notifications.where(read: false).exists? %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,0 +1,59 @@
+<h2 class="responsive-title">プロフィール編集</h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, multipart: true }) do |f| %>
+  <% if resource.errors.any? %>
+    <div class="alert alert-danger">
+      <h4>入力に問題があります:</h4>
+      <ul>
+        <% resource.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :name, "名前" %><br>
+    <%= f.text_field :name, autofocus: true, class: "form-control" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :bio, "自己紹介" %><br>
+    <%= f.text_area :bio, rows: 5, class: "form-control" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :avatar, "アバター" %><br>
+    <%= f.file_field :avatar, class: "form-control" %>
+    <% if resource.avatar.attached? %>
+      <p>現在のアバター:</p>
+      <%= image_tag resource.avatar.variant(resize_to_limit: [150, 150]) %>
+    <% end %>
+  </div>
+
+  <div class="field">
+    <%= f.label :email, "メールアドレス" %><br>
+    <%= f.email_field :email, class: "form-control" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password, "新しいパスワード（変更する場合）" %><br>
+    <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation, "新しいパスワード確認" %><br>
+    <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :current_password, "現在のパスワード（必須）" %><br>
+    <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control" %>
+  </div>
+
+  <div class="actions mt-3">
+    <%= f.submit "更新", class: "btn btn-primary" %>
+  </div>
+<% end %>
+
+<%= link_to "アカウント削除", registration_path(resource_name), data: { confirm: "本当に削除しますか？" }, method: :delete, class: "btn btn-danger mt-2" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: "users/registrations"
+  }
+
+  resources :users, only: [:show]
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/migrate/20250829072700_add_profile_to_users.rb
+++ b/db/migrate/20250829072700_add_profile_to_users.rb
@@ -1,0 +1,6 @@
+class AddProfileToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :name, :string, default: "ユーザー"
+    add_column :users, :bio, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_27_052733) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_29_072700) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -94,7 +94,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_27_052733) do
     t.bigint "child_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.index ["child_id"], name: "index_diapers_on_child_id"
     t.index ["user_id"], name: "index_diapers_on_user_id"
   end
@@ -166,7 +166,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_27_052733) do
     t.text "memo"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.index ["child_id"], name: "index_schedules_on_child_id"
     t.index ["user_id"], name: "index_schedules_on_user_id"
   end
@@ -213,6 +213,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_27_052733) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name", default: "ユーザー"
+    t.text "bio"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
@@ -238,16 +240,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_27_052733) do
   add_foreign_key "bottles", "children"
   add_foreign_key "bottles", "users"
   add_foreign_key "diapers", "children"
-  add_foreign_key "diapers", "users"
   add_foreign_key "feeds", "children"
-  add_foreign_key "feeds", "users"
   add_foreign_key "growths", "children"
   add_foreign_key "hydrations", "children"
   add_foreign_key "hydrations", "users"
   add_foreign_key "notifications", "children"
   add_foreign_key "notifications", "users"
   add_foreign_key "schedules", "children"
-  add_foreign_key "schedules", "users"
   add_foreign_key "sleep_records", "children"
   add_foreign_key "sleep_records", "users"
   add_foreign_key "temperatures", "children"

--- a/spec/helpers/users/registrations_helper_spec.rb
+++ b/spec/helpers/users/registrations_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Users::RegistrationsHelper. For example:
+#
+# describe Users::RegistrationsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Users::RegistrationsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Users::Registrations", type: :request do
+  pending "usersコントローラー実装待ちのためテストスキップ中です"
+end


### PR DESCRIPTION
- Added name (default: "ユーザー") and bio columns to users table
- Added validations for name (presence, max 50) and bio (max 300) in User model
- Configured Devise registrations controller to permit name, bio, and avatar
- Added ActiveStorage attachment avatar to User model
- Added "プロフィール編集" link in header navigation pointing to edit_user_registration_path