### PR TITLE
Reconfigure Tailwind setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,11 +70,12 @@ group :development, :test do
   gem "rspec-rails"
 end
 
-gem "tailwindcss-rails", "~> 4.3"
-
 gem "jsbundling-rails", "~> 1.3"
 
 gem "simple_calendar", "~> 2.0"
 
 gem "image_processing", "~> 1.12"
 gem "ruby-vips", require: false, group: :production
+
+
+gem "tailwindcss-rails", "~> 4.3"

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,3 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss/theme.css" layer(theme);
+@import "tailwindcss/utilities.css" layer(utilities);
+@plugin "@tailwindcss/typography";
+@plugin "@tailwindcss/forms";

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,10 @@
 <h1 class="dashboard-title">ダッシュボード</h1>
 
 
+<div class="bg-red-500 text-white p-4">
+  Tailwind 効いてる？
+</div>
+
 <%# ----- 成長記録(グラフ) ----- %>
 <div class="stats">
   <% if @latest_height && @latest_weight %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,85 +18,85 @@
     <link rel="apple-touch-icon" href="/icon.png">
 
     <%# Includes all stylesheet files in app/assets/stylesheets %>
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "records", "schedule", "dashboard", "growth", "sleep_analysis", "notification", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
     <%= javascript_importmap_tags %>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="..." crossorigin="anonymous">
   </head>
   <body data-current-child-id="<%= current_child&.id %>">
-   <header class="site-header">
-     <% if user_signed_in? %>
-     <div class="relative">
-      <div id="user-menu" class="absolute right-0 mt-2 w-48 bg-white border rounded shadow">
-        <% if current_child.present? %>
-          <p>現在の子ども: <%= current_child.name %></p>
-        <% else %>
-          <p>子どもが選択されていません</p>
-        <% end %>
-
-        <%= form_with(url: switch_child_path, method: :post, local: true, data: {turbo: false}) do %>
-          <%= select_tag :id, options_from_collection_for_select(current_user.children, :id, :name, session[:current_child_id]) %>
-          <%= submit_tag "切り替え" %>
-        <% end %>
-
-        <nav class="header-nav">
-          <%= link_to "トップページ", root_path, class: "nav-btn" %>
-          <%= link_to "子どもを切り替える", children_path, class: "nav-btn" %>
-          <%= link_to "子供一覧", children_path, class: "nav-btn" %>
-          <%= link_to "子供の登録", new_child_path, class: "nav-btn" %>
-          <%= link_to "子供の編集・削除", children_path, class: "nav-btn" %>
-
-          <% if current_child.present? %>
-            <%= link_to "授乳一覧", child_feeds_path(current_child), class: "nav-btn" %>
-            <%= link_to "授乳の登録", new_child_feed_path(current_child), class: "nav-btn" %>
-            <%= link_to "おむつ一覧", child_diapers_path(current_child), class: "nav-btn" %>
-            <%= link_to "おむつの登録", new_child_diaper_path(current_child), class: "nav-btn" %>
-            <%= link_to "ミルク一覧", child_bottles_path(current_child), class: "nav-btn" %>
-            <%= link_to "ミルクの登録", new_child_bottle_path(current_child), class: "nav-btn" %>
-            <%= link_to "水分補給一覧", child_hydrations_path(current_child), class: "nav-btn" %>
-            <%= link_to "水分の登録", new_child_hydration_path(current_child), class: "nav-btn" %>
-            <%= link_to "離乳食一覧", child_baby_foods_path(current_child), class: "nav-btn" %>
-            <%= link_to "離乳食の登録", new_child_baby_food_path(current_child), class: "nav-btn" %>
-            <%= link_to "睡眠一覧", child_sleep_records_path(current_child), class: "nav-btn" %>
-            <%= link_to "睡眠の登録", new_child_sleep_record_path(current_child), class: "nav-btn" %>
-            <%= link_to "体温一覧", child_temperatures_path(current_child), class: "nav-btn" %>
-            <%= link_to "体温の登録", new_child_temperature_path(current_child), class: "nav-btn" %>
-            <%= link_to "お風呂一覧", child_baths_path(current_child), class: "nav-btn" %>
-            <%= link_to "お風呂の登録", new_child_bath_path(current_child), class: "nav-btn" %>
-            <%= link_to "予防接種一覧", child_vaccinations_path(current_child), class: "nav-btn" %>
-            <%= link_to "予防接種の登録", new_child_vaccination_path(current_child), class: "nav-btn" %>
-            <%= link_to "スケジュール一覧", child_schedules_path(current_child), class: "nav-btn" %>
-            <%= link_to "スケジュールの登録", new_child_schedule_path(current_child), class: "nav-btn" %>
-            <%= link_to "成長記録", child_growths_path(current_child), class: "nav-btn" %>
-            <%= link_to "成長記録の登録", new_child_growth_path(current_child), class: "nav-btn" %>
-            <%= link_to "プロフィールを見る", user_path(current_user), class: "nav-btn" %>
-            <%= link_to "プロフィールを編集", edit_user_registration_path(tab: "profile"), class: "nav-btn" %>
-            <%= link_to "パスワード変更", edit_user_registration_path(tab: "password"), class: "nav-btn" %>
-            <%= link_to notifications_path(current_child), class: "notification-link" do %>
-              <i class="fa fa-bell"></i>
-              <% if current_user.notifications.where(read: false).exists? %>
-                <span class="notification-count">
-                  <%= current_user.notifications.where(read: false).count %>
-                </span>
-              <% end %>
+    <header class="site-header">
+      <% if user_signed_in? %>
+        <div>
+          <div id="user-menu">
+            <% if current_child.present? %>
+              <p>現在の子ども: <%= current_child.name %></p>
+            <% else %>
+              <p>子どもが選択されていません</p>
             <% end %>
-          <% end %>
 
-          <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete }, class: "nav-btn" %>
-        </nav>
-      </div>
-    </div>
+            <%= form_with(url: switch_child_path, method: :post, local: true, data: {turbo: false}) do %>
+              <%= select_tag :id, options_from_collection_for_select(current_user.children, :id, :name, session[:current_child_id]) %>
+              <%= submit_tag "切り替え" %>
+            <% end %>
 
-  <% end %>
-</header>
+            <nav class="header-nav">
+              <%= link_to "トップページ", root_path, class: "nav-btn" %>
+              <%= link_to "子どもを切り替える", children_path, class: "nav-btn" %>
+              <%= link_to "子供一覧", children_path, class: "nav-btn" %>
+              <%= link_to "子供の登録", new_child_path, class: "nav-btn" %>
+              <%= link_to "子供の編集・削除", children_path, class: "nav-btn" %>
+
+              <% if current_child.present? %>
+                <%= link_to "授乳一覧", child_feeds_path(current_child), class: "nav-btn" %>
+                <%= link_to "授乳の登録", new_child_feed_path(current_child), class: "nav-btn" %>
+                <%= link_to "おむつ一覧", child_diapers_path(current_child), class: "nav-btn" %>
+                <%= link_to "おむつの登録", new_child_diaper_path(current_child), class: "nav-btn" %>
+                <%= link_to "ミルク一覧", child_bottles_path(current_child), class: "nav-btn" %>
+                <%= link_to "ミルクの登録", new_child_bottle_path(current_child), class: "nav-btn" %>
+                <%= link_to "水分補給一覧", child_hydrations_path(current_child), class: "nav-btn" %>
+                <%= link_to "水分の登録", new_child_hydration_path(current_child), class: "nav-btn" %>
+                <%= link_to "離乳食一覧", child_baby_foods_path(current_child), class: "nav-btn" %>
+                <%= link_to "離乳食の登録", new_child_baby_food_path(current_child), class: "nav-btn" %>
+                <%= link_to "睡眠一覧", child_sleep_records_path(current_child), class: "nav-btn" %>
+                <%= link_to "睡眠の登録", new_child_sleep_record_path(current_child), class: "nav-btn" %>
+                <%= link_to "体温一覧", child_temperatures_path(current_child), class: "nav-btn" %>
+                <%= link_to "体温の登録", new_child_temperature_path(current_child), class: "nav-btn" %>
+                <%= link_to "お風呂一覧", child_baths_path(current_child), class: "nav-btn" %>
+                <%= link_to "お風呂の登録", new_child_bath_path(current_child), class: "nav-btn" %>
+                <%= link_to "予防接種一覧", child_vaccinations_path(current_child), class: "nav-btn" %>
+                <%= link_to "予防接種の登録", new_child_vaccination_path(current_child), class: "nav-btn" %>
+                <%= link_to "スケジュール一覧", child_schedules_path(current_child), class: "nav-btn" %>
+                <%= link_to "スケジュールの登録", new_child_schedule_path(current_child), class: "nav-btn" %>
+                <%= link_to "成長記録", child_growths_path(current_child), class: "nav-btn" %>
+                <%= link_to "成長記録の登録", new_child_growth_path(current_child), class: "nav-btn" %>
+                <%= link_to "プロフィールを見る", user_path(current_user), class: "nav-btn" %>
+                <%= link_to "プロフィールを編集", edit_user_registration_path(tab: "profile"), class: "nav-btn" %>
+                <%= link_to "パスワード変更", edit_user_registration_path(tab: "password"), class: "nav-btn" %>
+                <%= link_to notifications_path(current_child), class: "notification-link" do %>
+                  <i class="fa fa-bell"></i>
+                  <% if current_user.notifications.where(read: false).exists? %>
+                    <span class="notification-count">
+                      <%= current_user.notifications.where(read: false).count %>
+                    </span>
+                  <% end %>
+                <% end %>
+              <% end %>
+
+              <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete }, class: "nav-btn" %>
+            </nav>
+          </div>
+        </div>
+      <% end %>
+    </header>
    
-  <% if notice %>
-    <p class="notice"><%= notice %></p>
-  <% end %>
-  <% if alert %>
-    <p class="alert"><%= alert %></p>
-  <% end %>
-  <%= render "layouts/notification_popup" %>
-  <%= yield %>
+    <% if notice %>
+      <p class="notice"><%= notice %></p>
+    <% end %>
+    <% if alert %>
+      <p class="alert"><%= alert %></p>
+    <% end %>
+    <%= render "layouts/notification_popup" %>
+    <%= yield %>
   </body>
 </html>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -94,7 +94,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_30_193002) do
     t.bigint "child_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
+    t.bigint "user_id"
     t.index ["child_id"], name: "index_diapers_on_child_id"
     t.index ["user_id"], name: "index_diapers_on_user_id"
   end
@@ -166,7 +166,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_30_193002) do
     t.text "memo"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
+    t.bigint "user_id"
     t.index ["child_id"], name: "index_schedules_on_child_id"
     t.index ["user_id"], name: "index_schedules_on_user_id"
   end
@@ -215,6 +215,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_30_193002) do
     t.datetime "updated_at", null: false
     t.string "name", default: "ユーザー"
     t.text "bio"
+    t.string "otp_secret"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
@@ -240,13 +241,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_30_193002) do
   add_foreign_key "bottles", "children"
   add_foreign_key "bottles", "users"
   add_foreign_key "diapers", "children"
+  add_foreign_key "diapers", "users"
   add_foreign_key "feeds", "children"
+  add_foreign_key "feeds", "users"
   add_foreign_key "growths", "children"
   add_foreign_key "hydrations", "children"
   add_foreign_key "hydrations", "users"
   add_foreign_key "notifications", "children"
   add_foreign_key "notifications", "users"
   add_foreign_key "schedules", "children"
+  add_foreign_key "schedules", "users"
   add_foreign_key "sleep_records", "children"
   add_foreign_key "sleep_records", "users"
   add_foreign_key "temperatures", "children"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
     "build": "esbuild app/javascript/application.js --bundle --outdir=app/assets/builds"
   },
   "devDependencies": {
-    "esbuild": "^0.25.7",
-    "tailwindcss": "^4.1.11"
+    "esbuild": "^0.25.7"
   },
   "dependencies": {
     "@hotwired/turbo-rails": "^8.0.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -198,8 +198,3 @@ esbuild@^0.25.7:
     "@esbuild/win32-arm64" "0.25.8"
     "@esbuild/win32-ia32" "0.25.8"
     "@esbuild/win32-x64" "0.25.8"
-
-tailwindcss@^4.1.11:
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-4.1.11.tgz#799af3e98c19c5baaefafc6e0c16304a0e684854"
-  integrity sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==


### PR DESCRIPTION
- Move `tailwindcss-rails` gem declaration to the end of Gemfile
- Update `application.css` to use `@import` syntax and include typography/forms plugins
- Adjust layout HTML to remove Tailwind utility classes from header/user menu
- Update home index to test Tailwind styling
- Remove Tailwind from package.json/yarn.lock devDependencies
- Add foreign keys for `users` on relevant tables in schema