### PR TITLE
Refactor notification services: add target_type to avoid cross-model …

### DIFF
--- a/app/services/bottle_notification_service.rb
+++ b/app/services/bottle_notification_service.rb
@@ -1,7 +1,7 @@
 # app/services/bottle_notification_service.rb
 class BottleNotificationService
-  NOTIFICATION_HOURS = { reminder: [3, 4] }
-  DAILY_ALERT_INTERVALS = [3, 6, 9, 12, 15, 18, 21]
+  NOTIFICATION_HOURS = { reminder: [ 3, 4 ] }
+  DAILY_ALERT_INTERVALS = [ 3, 6, 9, 12, 15, 18, 21 ]
 
   def self.create_notifications_for(child)
     latest_bottle = child.bottles.order(given_at: :desc).first

--- a/app/services/bottle_notification_service.rb
+++ b/app/services/bottle_notification_service.rb
@@ -1,29 +1,25 @@
+# app/services/bottle_notification_service.rb
 class BottleNotificationService
-  NOTIFICATION_HOURS = {
-    reminder: [ 3, 4 ] # 3時間と4時間でリマインダー
-  }
-
-  DAILY_ALERT_INTERVALS = [ 3, 6, 9, 12, 15, 18, 21 ] # 3時間ごとのチェック
+  NOTIFICATION_HOURS = { reminder: [3, 4] }
+  DAILY_ALERT_INTERVALS = [3, 6, 9, 12, 15, 18, 21]
 
   def self.create_notifications_for(child)
     latest_bottle = child.bottles.order(given_at: :desc).first
-    return unless latest_bottle # 1件もなければ通知出さない
+    return unless latest_bottle
 
     # --- 時間経過リマインダー ---
     hours_since_last_bottle = ((Time.current - latest_bottle.given_at) / 1.hour).floor
-
     NOTIFICATION_HOURS.each do |kind, hours_array|
       next unless hours_array.include?(hours_since_last_bottle)
 
       notification_exists = Notification.where(
         child: child,
         target: latest_bottle,
+        target_type: "Bottle",
         notification_kind: kind
       ).where("message LIKE ?", "%#{hours_since_last_bottle}時間%").exists?
 
       next if notification_exists
-
-      message = "リマインダー: 前回のミルクから#{hours_since_last_bottle}時間経過しました"
 
       Notification.create!(
         user: latest_bottle.user,
@@ -31,7 +27,7 @@ class BottleNotificationService
         target: latest_bottle,
         notification_kind: kind,
         title: "🍼 ミルク",
-        message: message,
+        message: "リマインダー: 前回のミルクから#{hours_since_last_bottle}時間経過しました",
         delivered_at: Time.current
       )
     end
@@ -42,24 +38,20 @@ class BottleNotificationService
     today_count   = today_bottles.count
     daily_goal    = child.daily_bottle_goal || 600
 
-    # 今日のレコードが0件でも、使ったことあるユーザーなら 0ml として扱う
+    # 過去に1件でも Bottle を登録していれば本日0件でも 0ml として扱う
+    today_total = 0 if today_bottles.empty? && child.bottles.exists?
     return if today_total >= daily_goal
 
     hours_since_midnight = ((Time.current - Time.current.beginning_of_day) / 1.hour).floor
-
     DAILY_ALERT_INTERVALS.each do |interval|
-      # interval時間帯のチェック（3時間区切り）
       next unless hours_since_midnight >= interval && hours_since_midnight < interval + 3
 
-      # 同じ interval 帯で既に通知があるかチェック
       notification_exists = Notification.where(
         child: child,
+        target_type: "Bottle",
         notification_kind: :alert
       ).where("message LIKE ?", "%#{today_total}ml%").exists?
-
       next if notification_exists
-
-      message = "アラート: 今日のミルク摂取量が不足しています（現在 #{today_total}ml / #{today_count}回 / 目標 #{daily_goal}ml）"
 
       Notification.create!(
         user: latest_bottle.user,
@@ -67,7 +59,7 @@ class BottleNotificationService
         target: latest_bottle,
         notification_kind: :alert,
         title: "🍼 ミルク不足アラート",
-        message: message,
+        message: "アラート: 今日のミルク摂取量が不足しています（現在 #{today_total}ml / #{today_count}回 / 目標 #{daily_goal}ml）",
         delivered_at: Time.current
       )
     end

--- a/app/services/diaper_notification_service.rb
+++ b/app/services/diaper_notification_service.rb
@@ -1,7 +1,7 @@
 class DiaperNotificationService
   NOTIFICATION_HOURS = {
-    reminder: [3, 4], # 3時間と4時間のリマインダー
-    alert: [5, 6]     # 5時間と6時間のアラート
+    reminder: [ 3, 4 ], # 3時間と4時間のリマインダー
+    alert: [ 5, 6 ]     # 5時間と6時間のアラート
   }
 
   def self.create_notifications_for(child)
@@ -24,11 +24,11 @@ class DiaperNotificationService
         next if notification_exists
 
         message = case kind
-                  when :reminder
+        when :reminder
                     "リマインダー: 前回のオムツ交換から#{hours_since_last_change}時間経過しました"
-                  when :alert
+        when :alert
                     "アラート: 前回のオムツ交換から#{hours_since_last_change}時間以上経過しています"
-                  end
+        end
 
         Notification.create!(
           user: latest_diaper.user || child.user,

--- a/app/services/diaper_notification_service.rb
+++ b/app/services/diaper_notification_service.rb
@@ -1,47 +1,45 @@
 class DiaperNotificationService
   NOTIFICATION_HOURS = {
-    reminder: [ 3, 4 ], # 3時間と4時間のリマインダー
-    alert: [ 5, 6 ]     # 5時間と6時間のアラート
+    reminder: [3, 4], # 3時間と4時間のリマインダー
+    alert: [5, 6]     # 5時間と6時間のアラート
   }
 
   def self.create_notifications_for(child)
     latest_diaper = child.diapers.order(changed_at: :desc).first
-    return unless latest_diaper
 
-    hours_since_last_change = ((Time.current - latest_diaper.changed_at) / 1.hour).floor
+    if latest_diaper
+      hours_since_last_change = ((Time.current - latest_diaper.changed_at) / 1.hour).floor
 
-    NOTIFICATION_HOURS.each do |kind, hours_array|
-      next unless hours_array.include?(hours_since_last_change)
+      NOTIFICATION_HOURS.each do |kind, hours_array|
+        next unless hours_array.include?(hours_since_last_change)
 
-      # 同じ Diaper, 同じ kind, 同じ時間の通知が既にあるかチェック
-      notification_exists = Notification.exists?(
-        child: child,
-        target: latest_diaper,
-        notification_kind: kind
-      ) && Notification.where(
-        child: child,
-        target: latest_diaper,
-        notification_kind: kind
-      ).where("message LIKE ?", "%#{hours_since_last_change}時間%").exists?
+        # 同じ Diaper, 同じ kind, 同じ時間の通知が既にあるかチェック
+        notification_exists = Notification.where(
+          child: child,
+          target_type: "Diaper",
+          target_id: latest_diaper.id,
+          notification_kind: kind
+        ).where("message LIKE ?", "%#{hours_since_last_change}時間%").exists?
 
-      next if notification_exists
+        next if notification_exists
 
-      message = case kind
-      when :reminder
-                  "リマインダー: 前回のオムツ交換から#{hours_since_last_change}時間経過しました"
-      when :alert
-                  "アラート: 前回のオムツ交換から#{hours_since_last_change}時間以上経過しています"
+        message = case kind
+                  when :reminder
+                    "リマインダー: 前回のオムツ交換から#{hours_since_last_change}時間経過しました"
+                  when :alert
+                    "アラート: 前回のオムツ交換から#{hours_since_last_change}時間以上経過しています"
+                  end
+
+        Notification.create!(
+          user: latest_diaper.user || child.user,
+          child: child,
+          target: latest_diaper,
+          notification_kind: kind,
+          title: "💩 おむつ",
+          message: message,
+          delivered_at: Time.current
+        )
       end
-
-      Notification.create!(
-        user: latest_diaper.user,
-        child: child,
-        target: latest_diaper,
-        notification_kind: kind,
-        title: "💩 おむつ",
-        message: message,
-        delivered_at: Time.current
-      )
     end
   end
 end

--- a/app/services/feed_notification_service.rb
+++ b/app/services/feed_notification_service.rb
@@ -1,47 +1,45 @@
 class FeedNotificationService
   NOTIFICATION_HOURS = {
-    reminder: [ 3, 4 ], # 3時間と4時間のリマインダー
-    alert: [ 5 ]         # 5時間以上でアラート
+    reminder: [3, 4], # 3時間と4時間のリマインダー
+    alert: [5]        # 5時間以上でアラート
   }
 
   def self.create_notifications_for(child)
     latest_feed = child.feeds.order(fed_at: :desc).first
-    return unless latest_feed
 
-    hours_since_last_feed = ((Time.current - latest_feed.fed_at) / 1.hour).floor
+    if latest_feed
+      hours_since_last_feed = ((Time.current - latest_feed.fed_at) / 1.hour).floor
 
-    NOTIFICATION_HOURS.each do |kind, hours_array|
-      next unless hours_array.include?(hours_since_last_feed)
+      NOTIFICATION_HOURS.each do |kind, hours_array|
+        next unless hours_array.include?(hours_since_last_feed)
 
-      # 同じ Feed, 同じ kind, 同じ時間の通知が既にあるかチェック（LIKE で部分一致）
-      notification_exists = Notification.exists?(
-        child: child,
-        target: latest_feed,
-        notification_kind: kind
-      ) && Notification.where(
-        child: child,
-        target: latest_feed,
-        notification_kind: kind
-      ).where("message LIKE ?", "%#{hours_since_last_feed}時間%").exists?
+        # 同じ Feed, 同じ kind, 同じ時間の通知が既にあるかチェック
+        notification_exists = Notification.where(
+          child: child,
+          target_type: "Feed",
+          target_id: latest_feed.id,
+          notification_kind: kind
+        ).where("message LIKE ?", "%#{hours_since_last_feed}時間%").exists?
 
-      next if notification_exists
+        next if notification_exists
 
-      message = case kind
-      when :reminder
-                  "リマインダー: 前回の授乳から#{hours_since_last_feed}時間経過しました"
-      when :alert
-                  "アラート: 授乳間隔が通常より長すぎます！（#{hours_since_last_feed}時間）"
+        message = case kind
+                  when :reminder
+                    "リマインダー: 前回の授乳から#{hours_since_last_feed}時間経過しました"
+                  when :alert
+                    "アラート: 授乳間隔が通常より長すぎます！（#{hours_since_last_feed}時間）"
+                  end
+
+        Notification.create!(
+          user: latest_feed.user || child.user,
+          child: child,
+          target: latest_feed,
+          notification_kind: kind,
+          title: "🍼 授乳（feed）",
+          message: message,
+          delivered_at: Time.current
+        )
       end
-
-      Notification.create!(
-        user: latest_feed.user,
-        child: child,
-        target: latest_feed,
-        notification_kind: kind,
-        title: "🍼 授乳（feed）",
-        message: message,
-        delivered_at: Time.current
-      )
     end
   end
 end

--- a/app/services/feed_notification_service.rb
+++ b/app/services/feed_notification_service.rb
@@ -1,7 +1,7 @@
 class FeedNotificationService
   NOTIFICATION_HOURS = {
-    reminder: [3, 4], # 3時間と4時間のリマインダー
-    alert: [5]        # 5時間以上でアラート
+    reminder: [ 3, 4 ], # 3時間と4時間のリマインダー
+    alert: [ 5 ]        # 5時間以上でアラート
   }
 
   def self.create_notifications_for(child)
@@ -24,11 +24,11 @@ class FeedNotificationService
         next if notification_exists
 
         message = case kind
-                  when :reminder
+        when :reminder
                     "リマインダー: 前回の授乳から#{hours_since_last_feed}時間経過しました"
-                  when :alert
+        when :alert
                     "アラート: 授乳間隔が通常より長すぎます！（#{hours_since_last_feed}時間）"
-                  end
+        end
 
         Notification.create!(
           user: latest_feed.user || child.user,

--- a/app/services/hydration_notification_service.rb
+++ b/app/services/hydration_notification_service.rb
@@ -1,7 +1,7 @@
 # app/services/hydration_notification_service.rb
 class HydrationNotificationService
-  NOTIFICATION_HOURS = { reminder: [3, 4] }
-  DAILY_ALERT_INTERVALS = [3, 6, 9, 12, 15, 18, 21]
+  NOTIFICATION_HOURS = { reminder: [ 3, 4 ] }
+  DAILY_ALERT_INTERVALS = [ 3, 6, 9, 12, 15, 18, 21 ]
 
   def self.create_notifications_for(child)
     latest_hydration = child.hydrations.order(fed_at: :desc).first

--- a/app/services/hydration_notification_service.rb
+++ b/app/services/hydration_notification_service.rb
@@ -1,79 +1,66 @@
+# app/services/hydration_notification_service.rb
 class HydrationNotificationService
-  NOTIFICATION_HOURS = {
-    reminder: [ 3, 4 ] # 3時間と4時間でリマインダー
-  }
-
-  DAILY_ALERT_INTERVALS = [ 3, 6, 9, 12, 15, 18, 21 ] # 3時間ごとのチェック
+  NOTIFICATION_HOURS = { reminder: [3, 4] }
+  DAILY_ALERT_INTERVALS = [3, 6, 9, 12, 15, 18, 21]
 
   def self.create_notifications_for(child)
     latest_hydration = child.hydrations.order(fed_at: :desc).first
-    return unless latest_hydration
 
     # --- 時間経過リマインダー ---
-    hours_since_last_hydration = ((Time.current - latest_hydration.fed_at) / 1.hour).floor
+    if latest_hydration
+      hours_since_last_hydration = ((Time.current - latest_hydration.fed_at) / 1.hour).floor
+      NOTIFICATION_HOURS.each do |kind, hours_array|
+        next unless hours_array.include?(hours_since_last_hydration)
 
-    NOTIFICATION_HOURS.each do |kind, hours_array|
-      next unless hours_array.include?(hours_since_last_hydration)
+        notification_exists = Notification.where(
+          child: child,
+          target: latest_hydration,
+          target_type: "Hydration",
+          notification_kind: kind
+        ).where("message LIKE ?", "%#{hours_since_last_hydration}時間%").exists?
+        next if notification_exists
 
-      notification_exists = Notification.where(
-        child: child,
-        target: latest_hydration,
-        notification_kind: kind
-      ).where("message LIKE ?", "%#{hours_since_last_hydration}時間%").exists?
-
-      next if notification_exists
-
-      message = "リマインダー: 前回の水分補給から#{hours_since_last_hydration}時間経過しました"
-
-      Notification.create!(
-        user: latest_hydration.user,
-        child: child,
-        target: latest_hydration,
-        notification_kind: kind,
-        title: "💧 水分補給",
-        message: message,
-        delivered_at: Time.current
-      )
+        Notification.create!(
+          user: latest_hydration.user,
+          child: child,
+          target: latest_hydration,
+          notification_kind: kind,
+          title: "💧 水分補給",
+          message: "リマインダー: 前回の水分補給から#{hours_since_last_hydration}時間経過しました",
+          delivered_at: Time.current
+        )
+      end
     end
 
     # --- 1日の摂取量チェック（不足アラート） ---
     today_hydrations = child.hydrations.where("DATE(fed_at) = ?", Date.current)
     past_hydrations  = child.hydrations.where.not(amount: nil)
-
-    # 過去に1回も amount が入力されていなければアラートは出さない
     return if past_hydrations.empty?
 
-    # 今日の amount が全て nil なら 0ml として扱う
     today_total = today_hydrations.sum(:amount) || 0
     today_count = today_hydrations.count { |h| h.amount.present? }
     daily_goal  = child.daily_hydration_goal || 200
-
-    # 目標を既に達成している場合は不要
     return if today_total >= daily_goal
 
     hours_since_midnight = ((Time.current - Time.current.beginning_of_day) / 1.hour).floor
-
     DAILY_ALERT_INTERVALS.each do |interval|
-      # interval時間帯のチェック（3時間区切り）
       next unless hours_since_midnight >= interval && hours_since_midnight < interval + 3
 
-      # 同じ interval 帯で既に通知があるかチェック
       notification_exists = Notification.where(
         child: child,
+        target_type: "Hydration",
         notification_kind: :alert
       ).where("message LIKE ?", "%#{today_total}ml%").exists?
-
       next if notification_exists
 
-      message = "アラート: 今日の水分摂取量が不足しています（現在 #{today_total}ml / #{today_count}回 / 目標 #{daily_goal}ml）"
-
+      target = latest_hydration
       Notification.create!(
-        user: latest_hydration.user,
+        user: target&.user || child.user,
         child: child,
-        target: latest_hydration,
+        target: target,
         notification_kind: :alert,
         title: "💧 水分補給不足アラート",
-        message: message,
+        message: "アラート: 今日の水分摂取量が不足しています（現在 #{today_total}ml / #{today_count}回 / 目標 #{daily_goal}ml）",
         delivered_at: Time.current
       )
     end


### PR DESCRIPTION
…conflicts

- BottleNotificationService, HydrationNotificationService, FeedNotificationService, DiaperNotificationService
  - Added target_type filtering in Notification queries
  - Prevents interference between different services (Bottle, Hydration, Feed, Diaper)
  - Simplified hash definitions and removed redundant comments
  - Ensures 0ml alerts for Bottle/Hydration when past records exist but no records today