### PR TITLE
Add button to switch to password change form on profile edit page

### DIFF
--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -63,6 +63,12 @@
   </div>
 <% end %>
 
+<% if @current_tab != "password" %>
+  <div class="profile-form-actions" style="margin-top: 1rem;">
+    <%= link_to "パスワード変更", edit_user_registration_path(tab: "password"), class: "profile-form-btn" %>
+  </div>
+<% end %>
+
 <div class="profile-form-actions">
   <%= link_to "アカウント削除", registration_path(resource_name), data: { confirm: "本当に削除しますか？" }, method: :delete, class: "profile-form-btn profile-form-btn-danger" %>
 </div>


### PR DESCRIPTION
  -Display a “パスワード変更” button below the profile form when the current tab is not “password”
  -Clicking the button navigates to the same edit page with tab: "password" parameter to show the password form