### PR TITLE
Add sorting feature to feeds index and generalize shared filter partial

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -3,7 +3,18 @@ class FeedsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @feeds = current_child.feeds.order(fed_at: :desc)
+    # 現在選択中の子どもの授乳記録を取得
+    @feeds = current_child.feeds
+
+    # 並び順指定
+    @feeds = case params[:sort]
+    when "date_desc"
+               @feeds.order(fed_at: :desc)
+    when "date_asc"
+               @feeds.order(fed_at: :asc)
+    else
+               @feeds.order(created_at: :desc)
+    end
   end
 
   def show

--- a/app/views/feeds/index.html.erb
+++ b/app/views/feeds/index.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/filters", url: child_feeds_path(current_child) %>
+
 <h2 class="responsive-title"><%= current_child.name %> の授乳記録一覧</h2>
 
 <table class="responsive-table">

--- a/app/views/shared/_filters.html.erb
+++ b/app/views/shared/_filters.html.erb
@@ -1,7 +1,7 @@
 <div class="filter-bar">
-  <%= form_with url: diaries_path, method: :get, local: true do |f| %>
+  <%= form_with url: (url || root_path), method: :get, local: true do |f| %>
     <label>並び順:
-      <%= f.select :sort, options_for_select([["日付が新しい順", "date_desc"], ["日付が古い順", "date_asc"]], params[:sort]) %>
+      <%= f.select :sort, options_for_select([["新しい順", "date_desc"], ["古い順", "date_asc"]], params[:sort]) %>
     </label>
     <%= f.submit "並び替え", class: "nav-btn" %>
   <% end %>


### PR DESCRIPTION
  -FeedsController#index now supports sorting by fed_at in ascending/descending order
  -_filters.html.erb partial updated to accept a url parameter, making it reusable for diaries, feeds, etc.
  -Feeds index view updated to render the shared filter partial with the correct path