### PR TITLE
Add child switch page and link in account menu

### DIFF
--- a/app/assets/stylesheets/swich_child_page.css
+++ b/app/assets/stylesheets/swich_child_page.css
@@ -1,0 +1,158 @@
+/* ==============================
+   子供切り替えページ専用スタイル
+   ============================== */
+
+/* ページ全体（背景グレー） */
+html, body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  background-color: #f3f4f6;
+}
+
+/* 全体コンテナ */
+.container {
+  min-height: 100vh;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* 白背景コンテナ */
+.white-box {
+  background-color: #fff;
+  width: 100%;
+  max-width: 500px;
+  height: 60vh;
+  padding: 2rem;
+  border-radius: 1.5rem;
+  box-shadow: 0 6px 15px rgba(0,0,0,0.08);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+/* 上余白 */
+.top-space {
+  height: 3%;
+}
+
+/* ロゴ */
+.logo span {
+  font-size: 2.5rem;
+  font-weight: bold;
+  color: #111827;
+  letter-spacing: 0.05em;
+}
+
+/* ロゴとタイトルの間隔 */
+.logo-title-space {
+  margin-top: 2rem;
+}
+
+/* タイトル */
+.title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #111827;
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+/* 子どもリスト */
+.children-list {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+/* 子ども1人分（form） */
+.children-list form {
+  width: 100%;
+  margin: 0;
+}
+
+/* 子どもボタン */
+.child-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  gap: 0.75rem;
+  background-color: #fff;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.child-item:hover {
+  background-color: #f3f4f6;
+}
+
+/* 子どもアイコン */
+.child-icon {
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  background-color: #e5e7eb;
+  border-radius: 50%;
+  padding: 0.3rem;
+}
+
+/* 追加ボタンのアイコンだけサイズと色を変更 */
+.add-child-item .child-icon {
+  background-color: #000; /* 背景は黒 */
+  border-radius: 50%;
+  padding: 0.3rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* 子ども情報 */
+.child-info {
+  display: flex;
+  flex-direction: column;
+  justify-content: center; /* 中央揃え */
+  text-align: left;
+  min-height: 2rem;        /* 必要に応じて高さを揃える */
+}
+
+/* 名前（太字） */
+.child-name {
+  font-weight: 700;
+  font-size: 1rem;
+  color: #111827;
+}
+
+/* 年齢 */
+.child-age {
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+/* 追加ボタン全体の高さを広げる */
+.add-child-item {
+  padding-top: 1.5rem;   /* 上余白を増やす */
+  padding-bottom: 1.5rem; /* 下余白を増やす */
+}
+
+/* 「別の子供を追加」の名前だけ通常フォント */
+.add-child-item .child-name {
+  font-weight: 400;
+}
+
+/* 子ども未登録時 */
+.no-child {
+  color: #6b7280;
+  text-align: center;
+  margin-top: 0.5rem;
+}
+
+/* 下余白 */
+.bottom-space {
+  margin-top: auto;
+}

--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -56,6 +56,10 @@ class ChildrenController < ApplicationController
     redirect_to children_path, notice: "子どもを切り替えました"
   end
 
+  def switch_page
+    @children = current_user.children
+  end
+
   # PATCH /children/:id/update_daily_goal
   def update_daily_goal
     # 更新できるカラムを許可

--- a/app/views/children/switch_page.html.erb
+++ b/app/views/children/switch_page.html.erb
@@ -1,0 +1,61 @@
+<div class="container">
+
+  <div class="white-box">
+
+    <div class="top-space"></div>
+
+    <div class="logo">
+      <span>IkujiApp</span>
+    </div>
+
+    <div class="logo-title-space"></div>
+
+    <h1 class="title">別の子供を選択または追加</h1>
+
+    <div class="children-list">
+
+      <% current_user.children.each do |child| %>
+        <%= form_with url: switch_child_path, method: :post, local: true do %>
+          <%= hidden_field_tag :id, child.id %>
+          <button type="submit" class="child-item">
+
+            <!-- 子どもアイコン -->
+            <svg class="child-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="gray">
+              <circle cx="12" cy="8" r="4"/>
+              <path d="M12 14c-4 0-6 2-6 4v2h12v-2c0-2-2-4-6-4z"/>
+            </svg>
+
+            <!-- 子ども情報 -->
+            <div class="child-info">
+              <span class="child-name"><%= child.name %></span>
+              <span class="child-age"><%= child.birth_date ? "#{((Time.zone.today - child.birth_date)/365).floor}歳" : "" %></span>
+            </div>
+
+          </button>
+        <% end %>
+      <% end %>
+
+      <!-- 別の子どもを追加ボタン（アイコンは既存子どもと同じ、テキストのみ通常フォント） -->
+      <%= form_with url: new_child_path, method: :get, local: true do %>
+        <button type="submit" class="child-item add-child-item">
+
+          <!-- アイコンは既存の子どもアイコンと同じ -->
+          <svg class="child-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white">
+            <circle cx="12" cy="8" r="4"/>
+            <path d="M12 14c-4 0-6 2-6 4v2h12v-2c0-2-2-4-6-4z"/>
+          </svg>
+
+          <!-- 名前だけ通常フォント -->
+          <div class="child-info">
+            <span class="child-name">別の子供を追加</span>
+          </div>
+
+        </button>
+      <% end %>
+
+    </div>
+
+    <div class="bottom-space"></div>
+
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
     <link rel="apple-touch-icon" href="/icon.png">
 
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
-    <%= stylesheet_link_tag "application", "sidebar", "records", "schedule", "dashboard", "growth", "sleep_analysis", "diary", "user_settings/profile", "user_settings/darkmode", "modals", "notification", "tips", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", "sidebar", "records", "schedule", "dashboard", "growth", "sleep_analysis", "diary", "user_settings/profile", "user_settings/darkmode", "modals", "notification", "tips", "swich_child_page", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
     <%= javascript_importmap_tags %>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" crossorigin="anonymous">
@@ -78,29 +78,7 @@
                 <% end %>
               </div>          
             </div>
-            <!-- 現在の子ども切替 -->
-            <div class="child-selector relative inline-block">
-             <% if current_child.present? %>
-                <!-- 選択中はフォームだけ表示 -->
-                <%= form_with(url: switch_child_path, method: :post, local: true, data: {turbo: false}, class: "inline-block") do %>
-                 <%= select_tag :id, options_from_collection_for_select(current_user.children, :id, :name, session[:current_child_id]), class: "border rounded px-2 py-1" %>
-                  <%= submit_tag "切り替え", class: "ml-2 px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600" %>
-                <% end %>
-              <% else %>
-               <!-- 未選択時はテキスト+矢印、クリックでフォーム表示 -->
-                <button type="button" class="px-3 py-1 border rounded bg-gray-100 hover:bg-gray-200 inline-flex items-center" id="child-toggle">
-                 子どもが選択されていません <span class="ml-1"></span>
-                </button>
-
-                <div id="child-menu" class="absolute hidden mt-1 bg-white border rounded shadow-md w-48 z-50">
-                 <%= form_with(url: switch_child_path, method: :post, local: true, data: {turbo: false}, class: "p-2") do %>
-                    <%= select_tag :id, options_from_collection_for_select(current_user.children, :id, :name, session[:current_child_id]), class: "w-full border rounded px-2 py-1 mb-2" %>
-                    <%= submit_tag "切り替え", class: "w-full px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600" %>
-                 <% end %>
-                </div>
-             <% end %>
-            </div>
-
+            
             <!-- 通知ベル -->
             <div class="notification">
               <% if current_child.present? %>
@@ -132,6 +110,7 @@
               <div id="account-menu" class="absolute right-0 hidden bg-white shadow-md rounded mt-2 w-40 z-50">
                 <%= link_to "アカウント設定", edit_user_registration_path, class: "block px-4 py-2 hover:bg-gray-100" %>
                 <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "block px-4 py-2 hover:bg-gray-100" %>
+                <%= link_to "子供を切り替える", switch_child_page_path, class: "block px-4 py-2 hover:bg-gray-100" %>
               </div>
             </div>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
+
+  get "switch_child_page", to: "children#switch_page", as: :switch_child_page
   post "switch_child", to: "children#switch", as: :switch_child
 
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)


### PR DESCRIPTION
- Implemented `switch_page` action in ChildrenController to list user's children
- Added dedicated stylesheet for child switch page
- Updated application layout to include link to child switch page in account menu
- Removed old inline child selector in header